### PR TITLE
Use the latest version of the plugin in examples rather than pinning to a specific one.

### DIFF
--- a/cheat-sheet.md
+++ b/cheat-sheet.md
@@ -21,7 +21,7 @@ To keep all the code examples consistent, we'll be using environment variables t
 export ACCOUNT='Your Video Cloud account ID'
 export EMAIL='The email address for you Video Cloud account'
 ```
-
+i
 Now, let's create a player:
 
 ```sh
@@ -140,16 +140,16 @@ One common reason for customizing a player is to add advertisements. If you're u
 ```json
 {
   "scripts": [
-    "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/videojs.ima3.min.js"
+    "https://players.brightcove.com/videojs-ima3/videojs.ima3.min.js"
   ],
   "stylesheets": [
-    "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/videojs.ima3.min.css",
+    "https://players.brightcove.com/videojs-ima3/videojs.ima3.min.css",
     "https://players.brightcove.com/2335723943001/service-webinar/alternate.css"
   ],
   "plugins": [{
     "name": "ima3",
     "options": {
-      "adSwf": "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/VideoJSIMA3.swf"
+      "adSwf": "https://players.brightcove.com/videojs-ima3/VideoJSIMA3.swf"
     }
   }]
 }

--- a/cheat-sheet.md
+++ b/cheat-sheet.md
@@ -21,7 +21,7 @@ To keep all the code examples consistent, we'll be using environment variables t
 export ACCOUNT='Your Video Cloud account ID'
 export EMAIL='The email address for you Video Cloud account'
 ```
-i
+
 Now, let's create a player:
 
 ```sh

--- a/config2.json
+++ b/config2.json
@@ -1,15 +1,15 @@
 {
   "scripts": [
-    "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/videojs.ima3.min.js"
+    "https://players.brightcove.com/videojs-ima3/videojs.ima3.min.js"
   ],
   "stylesheets": [
-    "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/videojs.ima3.min.css",
+    "https://players.brightcove.com/videojs-ima3/videojs.ima3.min.css",
     "https://players.brightcove.com/2335723943001/service-webinar/alternate.css"
   ],
   "plugins": [{
     "name": "ima3",
     "options": {
-      "adSwf": "https://players.brightcove.com/videojs/plugins/videojs-ima3/1.1.0/VideoJSIMA3.swf"
+      "adSwf": "https://players.brightcove.com/videojs-ima3/VideoJSIMA3.swf"
     }
   }]
 }


### PR DESCRIPTION
We have seen issues with the latest version of videojs and our earlier versions of the ima plugin.  We should use the path which will always have the latest version of the ima3 plugin in our examples.
